### PR TITLE
Use DKMS module instead of buster-backports kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 *[Lire ce readme en français.](./README_fr.md)*
 
-:warning: This app is still experimental. WireGuard requires upgrading your Linux kernel to another major version. Check its compatibility before running it on a production system. :warning:
+:warning: This app is still experimental. Check its compatibility before running it on a production system. :warning:
+
+:exclamation: WireGuard for YunoHost will add a DMKS module to your Linux kernel.
 
 > *This package allows you to install WireGuard quickly and simply on a YunoHost server.  
 If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/install) to learn how to install it.*

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@
 
 *[Read this readme in english.](./README.md)* 
 
-:warning: Cette app est encore expérimentale. WireGuard requiert de mettre à niveau votre noyau Linux. Vérifiez sa compatibilté avant de lancer l'installation sur un serveur de production. :warning:
+:warning: Cette app est encore expérimentale. Vérifiez sa compatibilté avant de lancer l'installation sur un serveur de production. :warning:
+
+:exclamation: WireGuard pour YunoHost ajoutera un module DKMS à votre noyau Linux.
 
 > *Ce package vous permet d'installer WireGuard rapidement et simplement sur un serveur YunoHost.  
 Si vous n'avez pas YunoHost, consultez [le guide](https://yunohost.org/#/install) pour apprendre comment l'installer.*

--- a/README_fr.md
+++ b/README_fr.md
@@ -80,5 +80,5 @@ Pour essayer la branche testing, procédez comme suit.
 ```
 sudo yunohost app install https://github.com/YunoHost-Apps/wireguard_ynh/tree/testing --debug
 ou
-sudo yunohost app upgrade REPLACEBYYOURAPP -u https://github.com/YunoHost-Apps/wireguard_ynh/tree/testing --debug
+sudo yunohost app upgrade wireguard -u https://github.com/YunoHost-Apps/wireguard_ynh/tree/testing --debug
 ```

--- a/check_process
+++ b/check_process
@@ -20,7 +20,7 @@
 		setup_private=1
 		setup_public=0
 		upgrade=1
-		#upgrade=1	from_commit=CommitHash
+		upgrade=1	from_commit=797a3e5990571629a8525764ce6e8d359277313f
 		backup_restore=1
 		multi_instance=0
 		port_already_use=0
@@ -32,7 +32,7 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=CommitHash
-		name=Name and date of the commit.
-		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr&is_public=1&password=pass&port=666&
+	; commit=797a3e5990571629a8525764ce6e8d359277313f
+		name=a version using backport kernel
+		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&is_public=1&
 

--- a/conf/sudoers.conf
+++ b/conf/sudoers.conf
@@ -1,0 +1,3 @@
+Cmnd_Alias WIREGUARDSERVICE = /bin/systemctl restart wg-quick@wg0.service
+
+__USER__ ALL = NOPASSWD: WIREGUARDSERVICE

--- a/conf/wireguard.service
+++ b/conf/wireguard.service
@@ -4,4 +4,6 @@ After=network.target
 
 [Service]
 Type=oneshot
+User=__APP__
+Group=__APP__
 ExecStart=/bin/systemctl restart wg-quick@wg0.service

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "email": "tituspijean@outlook.com"
     },
     "requirements": {
-        "yunohost": ">= 3.8.1"
+        "yunohost": ">= 4.0.8"
     },
     "multi_instance": false,
     "services": [

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="wireguard"
+pkg_dependencies="wireguard-dkms wireguard"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -39,6 +39,145 @@ ynh_detect_arch(){
 	echo $architecture
 }
 
+# Send an email to inform the administrator
+#
+# usage: ynh_send_readme_to_admin --app_message=app_message [--recipients=recipients] [--type=type]
+# | arg: -m --app_message= - The file with the content to send to the administrator.
+# | arg: -r, --recipients= - The recipients of this email. Use spaces to separate multiples recipients. - default: root
+#	example: "root admin@domain"
+#	If you give the name of a YunoHost user, ynh_send_readme_to_admin will find its email adress for you
+#	example: "root admin@domain user1 user2"
+# | arg: -t, --type= - Type of mail, could be 'backup', 'change_url', 'install', 'remove', 'restore', 'upgrade'
+ynh_send_readme_to_admin() {
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [m]=app_message= [r]=recipients= [t]=type= )
+	local app_message
+	local recipients
+	local type
+	# Manage arguments with getopts
+
+	ynh_handle_getopts_args "$@"
+	app_message="${app_message:-}"
+	recipients="${recipients:-root}"
+	type="${type:-install}"
+
+	# Get the value of admin_mail_html
+	admin_mail_html=$(ynh_app_setting_get $app admin_mail_html)
+	admin_mail_html="${admin_mail_html:-0}"
+
+	# Retrieve the email of users
+	find_mails () {
+		local list_mails="$1"
+		local mail
+		local recipients=" "
+		# Read each mail in argument
+		for mail in $list_mails
+		do
+			# Keep root or a real email address as it is
+			if [ "$mail" = "root" ] || echo "$mail" | grep --quiet "@"
+			then
+				recipients="$recipients $mail"
+			else
+				# But replace an user name without a domain after by its email
+				if mail=$(ynh_user_get_info "$mail" "mail" 2> /dev/null)
+				then
+					recipients="$recipients $mail"
+				fi
+			fi
+		done
+		echo "$recipients"
+	}
+	recipients=$(find_mails "$recipients")
+
+	# Subject base
+	local mail_subject="☁️🆈🅽🅷☁️: \`$app\`"
+
+	# Adapt the subject according to the type of mail required.
+	if [ "$type" = "backup" ]; then
+		mail_subject="$mail_subject has just been backup."
+	elif [ "$type" = "change_url" ]; then
+		mail_subject="$mail_subject has just been moved to a new URL!"
+	elif [ "$type" = "remove" ]; then
+		mail_subject="$mail_subject has just been removed!"
+	elif [ "$type" = "restore" ]; then
+		mail_subject="$mail_subject has just been restored!"
+	elif [ "$type" = "upgrade" ]; then
+		mail_subject="$mail_subject has just been upgraded!"
+	else	# install
+		mail_subject="$mail_subject has just been installed!"
+	fi
+
+	local mail_message="This is an automated message from your beloved YunoHost server.
+
+Specific information for the application $app.
+
+$(if [ -n "$app_message" ]
+then
+	cat "$app_message"
+else
+	echo "...No specific information..."
+fi)
+
+---
+Automatic diagnosis data from YunoHost
+
+__PRE_TAG1__$(yunohost tools diagnosis | grep -B 100 "services:" | sed '/services:/d')__PRE_TAG2__"
+
+	# Store the message into a file for further modifications.
+	echo "$mail_message" > mail_to_send
+
+	# If a html email is required. Apply html tags to the message.
+ 	if [ "$admin_mail_html" -eq 1 ]
+ 	then
+		# Insert 'br' tags at each ending of lines.
+		ynh_replace_string "$" "<br>" mail_to_send
+
+		# Insert starting HTML tags
+		sed --in-place '1s@^@<!DOCTYPE html>\n<html>\n<head></head>\n<body>\n@' mail_to_send
+
+		# Keep tabulations
+		ynh_replace_string "  " "\&#160;\&#160;" mail_to_send
+		ynh_replace_string "\t" "\&#160;\&#160;" mail_to_send
+
+		# Insert url links tags
+		ynh_replace_string "__URL_TAG1__\(.*\)__URL_TAG2__\(.*\)__URL_TAG3__" "<a href=\"\2\">\1</a>" mail_to_send
+
+		# Insert pre tags
+		ynh_replace_string "__PRE_TAG1__" "<pre>" mail_to_send
+		ynh_replace_string "__PRE_TAG2__" "<\pre>" mail_to_send
+
+		# Insert finishing HTML tags
+		echo -e "\n</body>\n</html>" >> mail_to_send
+
+	# Otherwise, remove tags to keep a plain text.
+	else
+		# Remove URL tags
+		ynh_replace_string "__URL_TAG[1,3]__" "" mail_to_send
+		ynh_replace_string "__URL_TAG2__" ": " mail_to_send
+
+		# Remove PRE tags
+		ynh_replace_string "__PRE_TAG[1-2]__" "" mail_to_send
+	fi
+
+	# Define binary to use for mail command
+	if [ -e /usr/bin/bsd-mailx ]
+	then
+		local mail_bin=/usr/bin/bsd-mailx
+	else
+		local mail_bin=/usr/bin/mail.mailutils
+	fi
+
+	if [ "$admin_mail_html" -eq 1 ]
+	then
+		content_type="text/html"
+	else
+		content_type="text/plain"
+	fi
+
+	# Send the email to the recipients
+	cat mail_to_send | $mail_bin -a "Content-Type: $content_type; charset=UTF-8" -s "$mail_subject" "$recipients"
+}
+
 #=================================================
 # FUTURE OFFICIAL HELPERS
 #=================================================

--- a/scripts/backup
+++ b/scripts/backup
@@ -63,6 +63,7 @@ ynh_backup --src_path="/etc/logrotate.d/$app"
 ynh_backup --src_path="/etc/systemd/system/$app.service"
 ynh_backup --src_path=/etc/systemd/system/wireguard_ui.service
 ynh_backup --src_path=/etc/systemd/system/wireguard.path
+ynh_backup --src_path="/etc/sudoers.d/${app}_ynh"
 
 #=================================================
 # BACKUP VARIOUS FILES

--- a/scripts/install
+++ b/scripts/install
@@ -75,7 +75,11 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=7
 
-ynh_install_extra_app_dependencies --repo="http://deb.debian.org/debian buster-backports main" --package="$pkg_dependencies"
+ynh_install_extra_repo --repo="http://deb.debian.org/debian buster-backports main"--priority=-1 --name=$app
+
+ynh_add_app_dependencies --package="$pkg_dependencies"
+
+ynh_remove_extra_repo --name=$app
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/install
+++ b/scripts/install
@@ -75,7 +75,20 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=7
 
-ynh_install_extra_app_dependencies --repo="http://deb.debian.org/debian buster-backports main" --package="$pkg_dependencies"
+# ynh_install_extra_app_dependencies --repo="http://deb.debian.org/debian buster-backports main" --package="$pkg_dependencies"
+
+#Add buster-backports repo
+ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
+
+#Add pin-priority for wireguard package
+ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" 995 --name="$app"
+
+# Update the list of package with the new repo
+ynh_package_update
+
+ynh_add_app_dependencies --package="$pkg_dependencies"
+
+ynh_remove_extra_repo --name=$app
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/install
+++ b/scripts/install
@@ -75,11 +75,7 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=7
 
-ynh_install_extra_repo --repo="http://deb.debian.org/debian buster-backports main"--priority=-1 --name=$app
-
-ynh_add_app_dependencies --package="$pkg_dependencies"
-
-ynh_remove_extra_repo --name=$app
+ynh_install_extra_app_dependencies --repo="http://deb.debian.org/debian buster-backports main" --package="$pkg_dependencies"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/install
+++ b/scripts/install
@@ -78,7 +78,7 @@ ynh_script_progression --message="Installing dependencies..." --weight=7
 #Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
-#Add pin-priority for wireguard package
+#Add pin-priority for wireguard packages
 ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo

--- a/scripts/install
+++ b/scripts/install
@@ -79,7 +79,7 @@ ynh_script_progression --message="Installing dependencies..." --weight=7
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
 #Add pin-priority for wireguard package
-ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" 995 --name="$app"
+ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo
 ynh_package_update

--- a/scripts/install
+++ b/scripts/install
@@ -114,6 +114,10 @@ ynh_script_progression --message="Configuring system user..." --weight=1
 # Create a system user
 ynh_system_user_create --username=$app
 
+# Ensure the system user has enough permissions
+install -b -o root -g root -m 0440 ../conf/sudoers.conf /etc/sudoers.d/${app}_ynh
+ynh_replace_string "__USER__" "${app}" /etc/sudoers.d/${app}_ynh
+
 #=================================================
 # SPECIFIC SETUP
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -75,8 +75,6 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=7
 
-# ynh_install_extra_app_dependencies --repo="http://deb.debian.org/debian buster-backports main" --package="$pkg_dependencies"
-
 #Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
@@ -88,6 +86,7 @@ ynh_package_update
 
 ynh_add_app_dependencies --package="$pkg_dependencies"
 
+#Remove buster-backports repo and pin-priority
 ynh_remove_extra_repo --name=$app
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -95,6 +95,15 @@ then
 fi
 
 #=================================================
+# SPECIFIC REMOVE
+#=================================================
+# REMOVE VARIOUS FILES
+#=================================================
+
+# Remove sudoers file
+ynh_secure_remove --file="/etc/sudoers.d/${app}_ynh"
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # REMOVE DEDICATED USER

--- a/scripts/restore
+++ b/scripts/restore
@@ -90,7 +90,7 @@ ynh_script_progression --message="Reinstalling dependencies..." --weight=5
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
 #Add pin-priority for wireguard package
-ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" 995 --name="$app"
+ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo
 ynh_package_update

--- a/scripts/restore
+++ b/scripts/restore
@@ -133,18 +133,6 @@ ynh_script_progression --message="Starting a systemd service..." --weight=1
 ynh_systemd_action --service_name=wireguard_ui --action="start" --log_path="/var/log/$app/ui.log"
 
 #=================================================
-# SETUP SSOWAT
-#=================================================
-ynh_script_progression --message="Configuring permissions..." --weight=1
-
-if [ $is_public -eq 1 ]
-then
-	ynh_permission_update --permission "main" --add visitors
-else
-	ynh_permission_update --permission "main" --remove "all_users" --add "$admin"
-fi
-
-#=================================================
 # RESTORE THE LOGROTATE CONFIGURATION
 #=================================================
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -85,7 +85,20 @@ chmod -R 750 $final_path/db
 ynh_script_progression --message="Reinstalling dependencies..." --weight=5
 
 # Define and install dependencies
-ynh_install_extra_app_dependencies --repo="http://http.debian.net/debian buster-backports main" --package=$pkg_dependencies
+
+#Add buster-backports repo
+ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
+
+#Add pin-priority for wireguard package
+ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" 995 --name="$app"
+
+# Update the list of package with the new repo
+ynh_package_update
+
+ynh_add_app_dependencies --package="$pkg_dependencies"
+
+#Remove buster-backports repo and pin-priority
+ynh_remove_extra_repo --name=$app
 
 #=================================================
 # RESTORE SYSTEMD

--- a/scripts/restore
+++ b/scripts/restore
@@ -89,7 +89,7 @@ ynh_script_progression --message="Reinstalling dependencies..." --weight=5
 #Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
-#Add pin-priority for wireguard package
+#Add pin-priority for wireguard packages
 ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo

--- a/scripts/restore
+++ b/scripts/restore
@@ -68,6 +68,9 @@ ynh_script_progression --message="Recreating the dedicated system user..." --wei
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app
 
+# Restore sudoers file
+ynh_restore_file --origin_path="/etc/sudoers.d/${app}_ynh"
+
 #=================================================
 # RESTORE USER RIGHTS
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -59,7 +59,7 @@ arch=$(ynh_detect_arch)
 linuximage_version=$(ynh_package_version --package=linux-image-$arch)
 if [[ $linuximage_version == *"bpo10"* ]]
 then
-	# Downgrading using ynh_package_install (exploded) without "--no-remove"
+	# Downgrading using ynh_package_install apt command without "--no-remove" and with "--allow-downgrades"
 	# It will remove wireguard-ynh-deps and wireguard but they will be reinstalled throught upgrade process
 	ynh_apt --allow-downgrades --option Dpkg::Options::=--force-confdef \
         --option Dpkg::Options::=--force-confold install linux-image-$arch/stable

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -104,7 +104,21 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Upgrading dependencies..." --weight=7
 
-ynh_install_extra_app_dependencies --repo="http://deb.debian.org/debian buster-backports main" --package="$pkg_dependencies"
+#TODO: remove buster-backports kernel
+
+#Add buster-backports repo
+ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
+
+#Add pin-priority for wireguard package
+ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" 995 --name="$app"
+
+# Update the list of package with the new repo
+ynh_package_update
+
+ynh_add_app_dependencies --package="$pkg_dependencies"
+
+#Remove buster-backports repo and pin-priority
+ynh_remove_extra_repo --name=$app
 
 #=================================================
 # CREATE DEDICATED USER

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -110,7 +110,7 @@ ynh_script_progression --message="Upgrading dependencies..." --weight=7
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
 #Add pin-priority for wireguard package
-ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" 995 --name="$app"
+ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo
 ynh_package_update

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,6 +54,15 @@ then
 	ynh_app_setting_set --app=$app --key=is_public --value=0
 fi
 
+# Downgrade linux-image-$arch if updated to the buster-backports version
+arch=$(ynh_detect_arch)
+linuximage_version=$(ynh_package_version --package=linux-image-$arch)
+if [[ $linuximage_version == *"bpo10"* ]]
+then
+	ynh_package_remove linux-image-$arch
+	ynh_package_install linux-image-$arch
+fi
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -59,7 +59,10 @@ arch=$(ynh_detect_arch)
 linuximage_version=$(ynh_package_version --package=linux-image-$arch)
 if [[ $linuximage_version == *"bpo10"* ]]
 then
-	ynh_package_install linux-image-$arch/stable
+	# Downgrading using ynh_package_install (exploded) without "--no-remove"
+	# It will remove wireguard-ynh-deps and wireguard but they will be reinstalled throught upgrade process
+	ynh_apt --option Dpkg::Options::=--force-confdef \
+        --option Dpkg::Options::=--force-confold install linux-image-$arch/stable
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -68,7 +68,7 @@ then
 	linuxkernel_version = $(uname -r)
 	if [[ $linuxkernel_version == *"bpo"* ]]
 	then
-		ynh_package_remove linux-image-$linuxkernel_version
+		ynh_package_remove "linux-image-$linuxkernel_version"
 
 		echo "You've been using an experimental version of wireguard_ynh, which was using the backports version of the linux kernel.
 Now wireguard_ynh use a DKMS module allowing itself to be used with the stable kernel, then the backports one was removed and a reboot is needed to go back to the stable one." > mail_to_send

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -65,10 +65,10 @@ then
         --option Dpkg::Options::=--force-confold install linux-image-$arch/stable
 
 	#Remove backports kernel if running on it and send a mail to the admin to ask him to reboot
-	linuxkernel_version = $(uname -r)
+	linuxkernel_version=$(uname -r)
 	if [[ $linuxkernel_version == *"bpo"* ]]
 	then
-		ynh_package_remove "linux-image-$linuxkernel_version"
+		ynh_package_remove linux-image-$linuxkernel_version
 
 		echo "You've been using an experimental version of wireguard_ynh, which was using the backports version of the linux kernel.
 Now wireguard_ynh use a DKMS module allowing itself to be used with the stable kernel, then the backports one was removed and a reboot is needed to go back to the stable one." > mail_to_send

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -63,6 +63,18 @@ then
 	# It will remove wireguard-ynh-deps and wireguard but they will be reinstalled throught upgrade process
 	ynh_apt --allow-downgrades --option Dpkg::Options::=--force-confdef \
         --option Dpkg::Options::=--force-confold install linux-image-$arch/stable
+
+	#Remove backports kernel if running on it and send a mail to the admin to ask him to reboot
+	linuxkernel_version = $(uname -r)
+	if [[ $linuxkernel_version == *"bpo"* ]]
+	then
+		ynh_package_remove linux-image-$linuxkernel_version
+
+		echo "You've been using an experimental version of wireguard_ynh, which was using the backports version of the linux kernel.
+Now wireguard_ynh use a DKMS module allowing itself to be used with the stable kernel, then the backports one was removed and a reboot is needed to go back to the stable one." > mail_to_send
+
+		ynh_send_readme_to_admin --app_message="mail_to_send" --recipients="admin" --type=upgrade
+	fi
 fi
 
 #=================================================
@@ -120,7 +132,7 @@ ynh_script_progression --message="Upgrading dependencies..." --weight=7
 #Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
-#Add pin-priority for wireguard package
+#Add pin-priority for wireguard packages
 ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -77,6 +77,12 @@ Now wireguard_ynh use a DKMS module allowing itself to be used with the stable k
 	fi
 fi
 
+# Add sudoers file if missing
+if [ -f "/etc/sudoers.d/${app}_ynh" ]; then
+	install -b -o root -g root -m 0440 ../conf/sudoers.conf /etc/sudoers.d/${app}_ynh
+	ynh_replace_string "__USER__" "${app}" /etc/sudoers.d/${app}_ynh
+fi
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -59,8 +59,7 @@ arch=$(ynh_detect_arch)
 linuximage_version=$(ynh_package_version --package=linux-image-$arch)
 if [[ $linuximage_version == *"bpo10"* ]]
 then
-	ynh_package_remove linux-image-$arch
-	ynh_package_install linux-image-$arch
+	ynh_package_install linux-image-$arch/stable
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -61,7 +61,7 @@ if [[ $linuximage_version == *"bpo10"* ]]
 then
 	# Downgrading using ynh_package_install (exploded) without "--no-remove"
 	# It will remove wireguard-ynh-deps and wireguard but they will be reinstalled throught upgrade process
-	ynh_apt --option Dpkg::Options::=--force-confdef \
+	ynh_apt --allow-downgrades --option Dpkg::Options::=--force-confdef \
         --option Dpkg::Options::=--force-confold install linux-image-$arch/stable
 fi
 


### PR DESCRIPTION
Closes #4 

## Problem
- *I think it would be better to use DKMS module instead of buster-backports kernel*

## Solution
- [x] Add wireguard-dkms as dependency
- [x] Edit scripts to set pin-priority for only wireguard packages to prevent buster-backports kernel to install
- [x] Bump YunoHost minimum version to prevent installation on stretch
- [x] Downgrade linux-image-$arch in upgrade script
- [x] Send a mail about the fact that the user run the backports kernel and should reboot to stable one ?
- [x] Remove the backports kernel automaticaly ~or notify the user to do it~

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested (except mail).
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wireguard_ynh%20PR8%20(tituspijean)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wireguard_ynh%20PR8%20(tituspijean)/)
