### PR TITLE
Install backports repo gpg key and linux-headers

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,6 +11,47 @@ pkg_dependencies="wireguard-dkms wireguard"
 # PERSONAL HELPERS
 #=================================================
 
+# Add gpg keys for repositories
+#
+# [internal]
+#
+# usage: ynh_install_repo_gpg --key=key_url --name=name [--append]
+# | arg: -k, --key=         - url to get the public key.
+# | arg: -n, --name=        - Name for the files for this repo, $app as default value.
+# | arg: -a, --append       - Do not overwrite existing files.
+#
+# Requires YunoHost version 3.8.1 or higher.
+ynh_install_repo_gpg () {
+    # Declare an array to define the options of this helper.
+    local legacy_args=kna
+    local -A args_array=( [k]=key= [n]=name= [a]=append )
+    local key
+    local name
+    local append
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    name="${name:-$app}"
+    append=${append:-0}
+    key=${key:-}
+
+    if [ $append -eq 1 ]
+    then
+        append="--append"
+        wget_append="tee --append"
+    else
+        append=""
+        wget_append="tee"
+    fi
+
+    # Get the public key for the repo
+    if [ -n "$key" ]
+    then
+        mkdir --parents "/etc/apt/trusted.gpg.d"
+        # Timeout option is here to enforce the timeout on dns query and tcp connect (c.f. man wget)
+        wget --timeout 900 --quiet "$key" --output-document=- | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.gpg > /dev/null
+    fi
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="wireguard-dkms wireguard"
+pkg_dependencies="linux-headers-$(uname --kernel-release) wireguard-dkms wireguard"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="linux-headers-$(uname --kernel-release) wireguard-dkms wireguard"
+pkg_dependencies="wireguard-dkms wireguard"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -73,6 +73,9 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=7
 
+# Add buster-backports gpg key
+ynh_install_repo_gpg --key="https://ftp.debian.org/debian/dists/buster-backports/Release.gpg" --name="$app"
+
 # Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 

--- a/scripts/install
+++ b/scripts/install
@@ -74,7 +74,7 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 ynh_script_progression --message="Installing dependencies..." --weight=7
 
 # Add buster-backports gpg key
-ynh_install_repo_gpg --key="https://ftp.debian.org/debian/dists/buster-backports/Release.gpg" --name="$app"
+ynh_install_repo_gpg --key="https://ftp-master.debian.org/keys/archive-key-10.asc" --name="$app"
 
 # Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -136,6 +136,9 @@ ynh_script_progression --message="Upgrading dependencies..." --weight=7
 
 #TODO: remove buster-backports kernel
 
+# Add buster-backports gpg key
+ynh_install_repo_gpg --key="https://ftp.debian.org/debian/dists/buster-backports/Release.gpg" --name="$app"
+
 # Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -137,7 +137,7 @@ ynh_script_progression --message="Upgrading dependencies..." --weight=7
 #TODO: remove buster-backports kernel
 
 # Add buster-backports gpg key
-ynh_install_repo_gpg --key="https://ftp.debian.org/debian/dists/buster-backports/Release.gpg" --name="$app"
+ynh_install_repo_gpg --key="https://ftp-master.debian.org/keys/archive-key-10.asc" --name="$app"
 
 # Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"


### PR DESCRIPTION
## Problem
- Users can be faced with the following error while installing the package:

`
W: GPG error: http://deb.debian.org/debian buster-backports InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 04EE7237B7D453EC NO_PUBKEY 648ACFD622F3D138
`
- We need to add linux-headers as dependency.
Closes #17 

## Solution
- Add the GPG key before installing the dependencies;
- Since we had to "explode" the main helper to tweak the pin priority in a previous PR, let's extract the key retrieval function;
- No need for a `ynh_remove_repo_gpg` function, as they get removed by `ynh_remove_extra_repo ` later on.