### PR TITLE
Fix installation on RPi and fix permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Virtual Private Networks (VPN) via WireGuard, with a web UI to ease configuration
 
-**Shipped version:** 0.2.7~ynh6
+**Shipped version:** 0.2.7~ynh7
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Réseaux Privés Virtuels (VPN) via WireGuard, avec une web UI pour faciliter sa configuration
 
-**Version incluse :** 0.2.7~ynh6
+**Version incluse :** 0.2.7~ynh7
 
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Virtual Private Networks (VPN) via WireGuard, with a web UI to ease configuration",
         "fr": "Réseaux Privés Virtuels (VPN) via WireGuard, avec une web UI pour faciliter sa configuration"
     },
-    "version": "0.2.7~ynh6",
+    "version": "0.2.7~ynh7",
     "url": "https://github.com/ngoduykhanh/wireguard-ui",
     "upstream": {
         "license": "MIT",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,14 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="linux-headers-$(uname -r) wireguard-dkms wireguard"
+if grep "Raspberry Pi" /proc/device-tree/model; then
+    pkg_headers="raspberrypi-kernel-headers"
+else
+    pkg_headers="linux-headers-$(uname -r)"
+fi
+
+# dependencies used by the app
+pkg_dependencies="$pkg_headers wireguard-dkms wireguard"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/backup
+++ b/scripts/backup
@@ -64,7 +64,7 @@ ynh_backup --src_path="/etc/sudoers.d/${app}_ynh"
 #=================================================
 
 # Backup the wireguard interface config
-ynh_backup --src_path=$(jq -r ".config_file_path" $final_path/db/server/global_settings.json)
+ynh_backup --src_path="/etc/wireguard"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -162,11 +162,13 @@ ynh_add_systemd_config --service=wireguard_ui_conf --template=wireguard_ui_conf.
 #=================================================
 
 # Set permissions to app files
-chown -R root: $final_path
-chown -R $app: $final_path/db
-chmod -R 750 $final_path/db
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app: "$final_path"
 
-chown -R $app:$app /etc/wireguard
+chmod 750 /etc/wireguard
+chmod -R o-rwx /etc/wireguard
+chown -R $app: /etc/wireguard
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,9 +75,13 @@ ynh_restore_file --origin_path="/etc/sudoers.d/${app}_ynh"
 #=================================================
 
 # Restore permissions on app files
-chown -R root: $final_path
-chown -R $app: $final_path/db
-chmod -R 750 $final_path/db
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app: "$final_path"
+
+chmod 750 /etc/wireguard
+chmod -R o-rwx /etc/wireguard
+chown -R $app: /etc/wireguard
 
 #=================================================
 # SPECIFIC RESTORATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -58,6 +58,7 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_script_progression --message="Restoring the app main directory..." --weight=1
 
 ynh_restore_file --origin_path="$final_path"
+ynh_restore_file --origin_path="/etc/wireguard"
 
 #=================================================
 # RECREATE THE DEDICATED USER

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -199,10 +199,14 @@ ynh_replace_string --match_string="__PORT_WG__" --replace_string="$port_wg" --ta
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-# Set permissions on app files
-chown -R root: $final_path
-chown -R $app: $final_path/db
-chmod -R 750 $final_path/db
+# Set permissions to app files
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app: "$final_path"
+
+chmod 750 /etc/wireguard
+chmod -R o-rwx /etc/wireguard
+chown -R $app: /etc/wireguard
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST


### PR DESCRIPTION
Closes #26 
Closes #25 
Closes #24 

## Problem

- `linux-headers-$(uname -r)` packages are not avaialble on RPi since they use their own package `raspberrypi-kernel-headers`
- Last upgrade set `root` as owner of `$final_path`, preventing the service from starting.

## Solution

- Add a test to determine if we need this dedicated package.
- `chown` all the things

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
