### PR TITLE
Systemd hardening

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,13 +1,8 @@
-# See here for more information
-# https://github.com/YunoHost/package_check#syntax-check_process-file
-
-# Move this file from check_process.default to check_process when you have filled it.
-
 ;; Test complet
 	; Manifest
-		domain="domain.tld"	(DOMAIN)
-		path="/"	(PATH)
-		admin="john"	(USER)
+		domain="domain.tld"
+		path="/"
+		admin="john"
 	; Checks
 		pkg_linter=1
 		setup_sub_dir=0
@@ -19,11 +14,7 @@
 		upgrade=1	from_commit=797a3e5990571629a8525764ce6e8d359277313f
 		backup_restore=1
 		multi_instance=0
-		port_already_use=0
 		change_url=0
-;;; Levels
-	# If the level 5 (Package linter) is forced to 1. Please add justifications here.
-	Level 5=auto
 ;;; Options
 Email=
 Notification=none

--- a/conf/wireguard_ui.service
+++ b/conf/wireguard_ui.service
@@ -9,5 +9,35 @@ Group=__APP__
 WorkingDirectory=__FINALPATH__/
 ExecStart=__FINALPATH__/wireguard-ui --bind-address="127.0.0.1:__PORT__" --disable-login
 
+# Sandboxing options to harden security
+# Depending on specificities of your service/app, you may need to tweak these 
+# .. but this should be a good baseline
+# Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+DevicePolicy=closed
+ProtectSystem=full
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+LockPersonality=yes
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+
+# Denying access to capabilities that should not be relevant for webapps
+# Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
+CapabilityBoundingSet=~CAP_RAWIO CAP_MKNOD
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
+CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG 
+
 [Install]
 WantedBy=multi-user.target

--- a/conf/wireguard_ui.service
+++ b/conf/wireguard_ui.service
@@ -39,5 +39,8 @@ CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
 CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
 CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG 
 
+# Exception to ProtectSystem
+ReadWritePaths=/etc/wireguard
+
 [Install]
 WantedBy=multi-user.target

--- a/scripts/backup
+++ b/scripts/backup
@@ -66,6 +66,9 @@ ynh_backup --src_path="/etc/sudoers.d/${app}_ynh"
 # Backup the wireguard interface config
 ynh_backup --src_path="/etc/wireguard"
 
+# Backing up specific config file, in case of it is not in /etc/wireguard
+ynh_backup --src_path="$(jq -r ".config_file_path" $final_path/db/server/global_settings.json)" --not_mandatory
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -155,6 +155,7 @@ systemctl enable --quiet wireguard_ui_conf.path
 
 # Create a dedicated systemd config for restarting WireGuard when its configuration changes
 ynh_add_systemd_config --service=wireguard_ui_conf --template=wireguard_ui_conf.service
+systemctl enable --quiet wireguard_ui_conf.service
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_app_setting_set --app=$app --key=admin --value=$admin
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_script_progression --message="Configuring firewall..." --weight=1
+ynh_script_progression --message="Finding an available port..." --weight=1
 
 # Find an available port for WireGuard
 port_wg=$(ynh_find_port --port=8095)
@@ -66,6 +66,7 @@ port=$(ynh_find_port --port=$(($port_wg+1)))
 ynh_app_setting_set --app=$app --key=port --value=$port
 
 # Open the WireGuard port
+ynh_script_progression --message="Configuring firewall..." --weight=1
 ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $port_wg
 
 #=================================================
@@ -102,7 +103,7 @@ ynh_setup_source --dest_dir="$final_path" --source_id="$(ynh_detect_arch)"
 #=================================================
 # NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Configuring nginx web server..." --weight=1
+ynh_script_progression --message="Configuring NGINX web server..." --weight=1
 
 # Create a dedicated nginx config
 ynh_add_nginx_config
@@ -175,8 +176,8 @@ chown -R $app: /etc/wireguard
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add wg-quick@wg0 --description "WireGuard VPN" --needs_exposed_ports $port_wg --test_status "wg show | grep wg0"
-yunohost service add wireguard_ui --description "WireGuard UI"
+yunohost service add wg-quick@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
+yunohost service add wireguard_ui --description="WireGuard UI"
 
 #=================================================
 # START SYSTEMD SERVICE
@@ -191,7 +192,7 @@ ynh_systemd_action --service_name=wireguard_ui --action="start" --line_match="ht
 #=================================================
 ynh_script_progression --message="Configuring permissions..." --weight=1
 
-ynh_permission_update --permission "main" --remove "all_users" --add "$admin"
+ynh_permission_update --permission="main" --remove="all_users" --add="$admin"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/remove
+++ b/scripts/remove
@@ -78,7 +78,7 @@ ynh_secure_remove --file="/etc/wireguard"
 #=================================================
 # REMOVE NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Removing nginx web server configuration..." --weight=1
+ynh_script_progression --message="Removing NGINX web server configuration..." --weight=1
 
 # Remove the dedicated nginx config
 ynh_remove_nginx_config
@@ -99,12 +99,6 @@ if yunohost firewall list | grep -q "\- $port_wg$"
 then
 	ynh_script_progression --message="Closing port $port_wg..." --weight=1
 	ynh_exec_warn_less yunohost firewall disallow UDP $port_wg
-fi
-
-if yunohost firewall list | grep -q "\- $port$"
-then
-        ynh_script_progression --message="Closing port $port..." --weight=1
-        ynh_exec_warn_less yunohost firewall disallow TCP $port
 fi
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -126,8 +126,8 @@ systemctl enable --quiet wireguard_ui_conf.service
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add wg-quick@wg0 --description "WireGuard VPN" --needs_exposed_ports "$port_wg" --test_status "wg show | grep wg0"
-yunohost service add wireguard_ui --description "WireGuard UI"
+yunohost service add wg-quick@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
+yunohost service add wireguard_ui --description="WireGuard UI"
 
 #=================================================
 # RESTORE VARIOUS FILES

--- a/scripts/restore
+++ b/scripts/restore
@@ -133,7 +133,7 @@ yunohost service add wireguard_ui --description "WireGuard UI"
 # RESTORE VARIOUS FILES
 #=================================================
 
-ynh_restore_file --origin_path=$(jq -r ".config_file_path" $final_path/db/server/global_settings.json)
+ynh_restore_file --origin_path=$(jq -r ".config_file_path" $final_path/db/server/global_settings.json) --not_mandatory
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/restore
+++ b/scripts/restore
@@ -94,10 +94,10 @@ ynh_script_progression --message="Reinstalling dependencies..." --weight=5
 # Add buster-backports gpg key
 ynh_install_repo_gpg --key="https://ftp-master.debian.org/keys/archive-key-10.asc" --name="$app"
 
-#Add buster-backports repo
+# Add buster-backports repo
 ynh_add_repo --uri="http://deb.debian.org/debian" --suite="buster-backports" --component="main" --name="$app"
 
-#Add pin-priority for wireguard packages
+# Add pin-priority for wireguard packages
 ynh_pin_repo --package="wireguard*" --pin="origin deb http://deb.debian.org/debian buster-backports main" --priority=995 --name="$app"
 
 # Update the list of package with the new repo
@@ -148,7 +148,7 @@ sleep 5
 #=================================================
 # RELOAD NGINX AND PHP-FPM
 #=================================================
-ynh_script_progression --message="Reloading nginx web server and php-fpm..." --weight=1
+ynh_script_progression --message="Reloading NGINX web server..." --weight=1
 
 ynh_systemd_action --service_name=nginx --action=reload
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -39,8 +39,6 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 #=================================================
 ynh_script_progression --message="Validating restoration parameters..." --weight=1
 
-ynh_webpath_available --domain=$domain --path_url=$path_url \
-	|| ynh_die --message="Path not available: ${domain}${path_url}"
 test ! -d $final_path \
 	|| ynh_die --message="There is already a directory: $final_path "
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -181,6 +181,7 @@ systemctl enable --quiet wireguard_ui_conf.path
 
 # Create a dedicated systemd config for restarting WireGuard when its configuration changes
 ynh_add_systemd_config --service=wireguard_ui_conf --template=wireguard_ui_conf.service
+systemctl enable --quiet wireguard_ui_conf.service
 
 #=================================================
 # CONFIGURING WIREGUARD

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -214,8 +214,8 @@ chown -R $app: /etc/wireguard
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add wg-quick@wg0 --description "WireGuard VPN" --needs_exposed_ports "$port_wg" --test_status "wg show | grep wg0"
-yunohost service add wireguard_ui --description "WireGuard UI"
+yunohost service add wg-quick@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
+yunohost service add wireguard_ui --description="WireGuard UI"
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
## Problem

- Systemd services can be secured with some hardening instructions

## Solution

- Follow example_ynh's ... example.
- Adding a rider commit for service starting at boot

Closes #31 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
