### PR TITLE
Fix change_url

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -69,7 +69,7 @@ fi
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --line_match="Stopped WireGuard UI" --log_path="systemd" --timeout=30
+ynh_systemd_action --service_name=wireguard_ui --action="stop" --line_match="Stopped WireGuard UI" --log_path="systemd" --timeout=30
 
 #=================================================
 # MODIFY URL IN NGINX CONF
@@ -113,7 +113,7 @@ fi
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --line_match="http server started" --log_path="systemd" --timeout=30
+ynh_systemd_action --service_name=wireguard_ui --action="start" --line_match="http server started" --log_path="systemd" --timeout=30
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

The `change_url` don't restart the web ui service and try to restart an nonexistant service.

https://paste.yunohost.org/raw/jijohasebe
```
2022-01-31 22:12:46,795: DEBUG - + ynh_systemd_action --service_name=wireguard --action=start '--line_match=http server started' --log_path=systemd --timeout=30
2022-01-31 22:12:47,024: DEBUG - + service_name=wireguard
2022-01-31 22:12:47,025: DEBUG - + action=start
2022-01-31 22:12:47,025: DEBUG - + line_match='http server started'
2022-01-31 22:12:47,025: DEBUG - + length=20
2022-01-31 22:12:47,026: DEBUG - + log_path=systemd
2022-01-31 22:12:47,026: DEBUG - + timeout=30
2022-01-31 22:12:47,026: DEBUG - + '[' start == stop ']'
2022-01-31 22:12:47,026: DEBUG - + [[ -n http server started ]]
2022-01-31 22:12:47,026: DEBUG - ++ mktemp
2022-01-31 22:12:47,027: DEBUG - + local templog=/tmp/tmp.wNwFWNfZbi
2022-01-31 22:12:47,027: DEBUG - + '[' systemd == systemd ']'
2022-01-31 22:12:47,027: DEBUG - + local pid_tail=825022
2022-01-31 22:12:47,028: DEBUG - + '[' start == reload ']'
2022-01-31 22:12:47,028: DEBUG - + systemctl start wireguard
2022-01-31 22:12:47,028: DEBUG - + journalctl --unit=wireguard --follow --since=-0 --quiet
2022-01-31 22:12:47,034: WARNING - Failed to start wireguard.service: Unit wireguard.service not found.

```

## Solution

- Restart wireguard_ui instead

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
