### PR TITLE
Only get the first interface listed as default from `ip route`

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -15,7 +15,7 @@ fi
 # dependencies used by the app
 pkg_dependencies="$pkg_headers wireguard-dkms wireguard"
 
-interface=$(ip route | awk '/default/ { print $5 }')
+interface=$(ip route | awk '/default/ { print $5 }' | head)
 
 main_domain=$(cat /etc/yunohost/current_host)
 


### PR DESCRIPTION
## Problem

- When a user have multi default route listed in `ip route`, the install crash when `ynh_add_config` calls `sed` with a new line.

Fix #53

## Solution

- Only get the first interface listed as default from `ip route`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
