### PR TITLE
Fix services not restarting when the UI updates the conf

### DIFF
--- a/conf/wireguard@.service
+++ b/conf/wireguard@.service
@@ -6,9 +6,7 @@ Wants=network-online.target nss-lookup.target
 [Service]
 Type=oneshot
 User=root
-RemainAfterExit=yes
 ExecStart=/bin/systemctl restart wg-quick@%I.service
-ExecStop=/bin/systemctl stop wg-quick@%I.service
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install
+++ b/scripts/install
@@ -180,7 +180,7 @@ chown -R $app: /etc/wireguard
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add wireguard@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
+yunohost service add wg-quick@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
 yunohost service add wireguard_ui --description="WireGuard UI"
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -35,10 +35,10 @@ then
 	yunohost service remove wireguard_ui
 fi
 
-if ynh_exec_warn_less yunohost service status wireguard@wg0 >/dev/null
+if ynh_exec_warn_less yunohost service status wg-quick@wg0 >/dev/null
 then
 	ynh_script_progression --message="Removing WireGuard service integration..." --weight=1
-	yunohost service remove wireguard@wg0
+	yunohost service remove wg-quick@wg0
 fi
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -132,7 +132,7 @@ sysctl -p /etc/sysctl.d/$app.conf
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add wireguard@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
+yunohost service add wg-quick@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
 yunohost service add wireguard_ui --description="WireGuard UI"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -107,6 +107,12 @@ if systemctl list-units --full -all | grep -Fq "wireguard_ui_conf.service"; then
 	ynh_secure_remove --file="/etc/systemd/system/wireguard_ui_conf.service"
 fi
 
+# Remove the service integration from an older version
+if ynh_exec_warn_less yunohost service status wireguard@wg0 >/dev/null
+then
+	yunohost service remove wireguard@wg0
+fi
+
 #=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
@@ -115,7 +121,7 @@ fi
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
 ynh_systemd_action --service_name=wireguard_ui --action="stop" --line_match="Stopped WireGuard UI" --log_path="systemd" --timeout=30
-ynh_systemd_action --service_name=wireguard@wg0 --action="stop"
+ynh_systemd_action --service_name=wg-quick@wg0 --action="stop"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -220,7 +226,7 @@ chown -R $app: /etc/wireguard
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add wireguard@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
+yunohost service add wg-quick@wg0 --description="WireGuard VPN" --needs_exposed_ports="$port_wg" --test_status="wg show | grep wg0"
 yunohost service add wireguard_ui --description="WireGuard UI"
 
 #=================================================


### PR DESCRIPTION
## Problems and solutions

This aims to fix #49 ! But with every solution, comes a new problem, so here's a list of "Problem : solution", chronologically :
- `wireguard@.service` will stay active after exit, preventing the `path` to start it again : remove `RemainAfterExit`.
- `wireguard@.service` have an `ExecStop` command, which will run every time after startup if it doesn't `RemainAfterExit` : remove the `ExecStop`.
- `wireguard@wg0.service` can't be stopped from `yunohost service stop` or the webadmin : change the service integration to use directly `wg-quick@wg0.service` instead.

## PR Status

~~This needs to be tested manually.~~
Manually tested and working great o/

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

[![Test Badge](https://img.shields.io/endpoint?url=https://bleu.cant.at/ci/api/job/19/badge)](https://bleu.cant.at/ci/job/19)
[![](https://bleu.cant.at/ci/summary/19.png)](https://bleu.cant.at/ci/job/19)